### PR TITLE
fix: add NEXT_PUBLIC_API_URL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ GOOGLE_AI_API_KEY=""
 API_PORT=3001
 WEB_PORT=3000
 WEB_URL="http://localhost:3000"
+NEXT_PUBLIC_API_URL="http://localhost:3001"
 
 # Stripe (optional — enterprise setup page)
 STRIPE_SECRET_KEY=""


### PR DESCRIPTION
The Next.js frontend needs this env variable to know where to send API requests.
Without it, API calls go to port 3000 (frontend) instead of 3001 (backend),
causing 404 errors on auth and other endpoints.