### PR TITLE
feat(ai): enable Anthropic prompt caching for system prompts

### DIFF
--- a/apps/api/src/modules/evals/evals.service.ts
+++ b/apps/api/src/modules/evals/evals.service.ts
@@ -231,7 +231,13 @@ export class EvalsService {
       },
       body: JSON.stringify({
         model,
-        system: systemPrompt,
+        system: [
+          {
+            type: 'text',
+            text: systemPrompt,
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
         messages: [{ role: 'user', content: userInput }],
         temperature: config?.temperature ?? 0,
         max_tokens: config?.maxTokens ?? 2000,

--- a/packages/ai/src/provider.ts
+++ b/packages/ai/src/provider.ts
@@ -13,7 +13,12 @@ export interface AIProviderConfig {
 export function createProvider(config: AIProviderConfig): any {
   switch (config.provider) {
     case 'ANTHROPIC': {
-      const anthropic = createAnthropic({ apiKey: config.apiKey });
+      const anthropic = createAnthropic({
+        apiKey: config.apiKey,
+        // Enable prompt caching — system prompts marked with cacheControl
+        // will be cached server-side, reducing input token costs by ~90%
+        cacheControl: true,
+      });
       return anthropic(config.model);
     }
     case 'OPENAI': {

--- a/packages/ai/src/runner.ts
+++ b/packages/ai/src/runner.ts
@@ -107,9 +107,25 @@ export class AgentRunner {
       }
     }
 
+    // For Anthropic: wrap system prompt with cacheControl to enable prompt caching.
+    // The provider must be created with cacheControl: true (see provider.ts).
+    // Other providers receive the plain string — they ignore the structured format.
+    const isAnthropic = this.config.provider.provider === 'ANTHROPIC';
+    const system = isAnthropic
+      ? [
+          {
+            type: 'text' as const,
+            text: this.config.systemPrompt,
+            providerOptions: {
+              anthropic: { cacheControl: { type: 'ephemeral' } },
+            },
+          },
+        ]
+      : this.config.systemPrompt;
+
     return {
       model: this.model,
-      system: this.config.systemPrompt,
+      system,
       tools: toolsMap,
       stopWhen: stepCountIs(maxSteps),
       maxTokens: this.config.maxTokens ?? 4096,


### PR DESCRIPTION
## Что сделано

Включён prompt caching для Anthropic Claude — системные промпты агентов теперь кэшируются на стороне Anthropic API.

## Изменения

### `packages/ai/src/provider.ts`
- Добавлен `cacheControl: true` при создании Anthropic провайдера через AI SDK

### `packages/ai/src/runner.ts`
- Системный промпт для Anthropic оборачивается в структурированный формат с `providerOptions.anthropic.cacheControl: { type: 'ephemeral' }`
- Для остальных провайдеров промпт передаётся как обычная строка (без изменений)

### `apps/api/src/modules/evals/evals.service.ts`
- В прямых REST-вызовах к Anthropic API поле `system` переведено из строки в массив с `cache_control: { type: 'ephemeral' }`

## Зачем

При повторных вызовах с одним и тем же системным промптом (а это каждое сообщение агента в чате) Anthropic кэширует промпт серверно:
- **~90% экономия** на входных токенах для кэшированной части
- **Быстрее ответы** — кэшированные токены не перечитываются
- Особенно заметно для агентов с длинными промптами (preamble + context + skills + memory)

## Совместимость

- Кэширование применяется только к Anthropic — остальные провайдеры работают без изменений
- Обратно совместимо: если Anthropic API не поддерживает кэширование для конкретной модели, поле просто игнорируется