### PR TITLE
docs: add ALLOW_PRISMA_DB_PUSH_FALLBACK to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,5 +24,8 @@ STRIPE_SECRET_KEY=""
 # Docker Compose
 POSTGRES_PASSWORD="agems"
 
+# Database migration fallback (set to true if DB was created via `db push` instead of migrations)
+ALLOW_PRISMA_DB_PUSH_FALLBACK=false
+
 # Catalog (central marketplace — leave default for community catalog from agems.ai)
 CATALOG_API_URL="https://agems.ai"


### PR DESCRIPTION
## Fix

Add `ALLOW_PRISMA_DB_PUSH_FALLBACK` to `.env.example`.

Databases created via `prisma db push` (common in early deployments) fail on `prisma migrate deploy` with error P3005 ("The database schema is not empty"). The entrypoint script already supports a fallback via this env var, but it wasn't documented in `.env.example`, causing 502 errors on deploy.