### PR TITLE
feat(budgets): platform-wide budget enforcement (hourly/daily/monthly)

### DIFF
--- a/apps/api/src/modules/budgets/budget-notifications.service.ts
+++ b/apps/api/src/modules/budgets/budget-notifications.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { SettingsService } from '../settings/settings.service';
+import { PrismaService } from '../../config/prisma.service';
+
+/**
+ * BudgetNotificationsService — listens to budget events and notifies the admin.
+ *
+ * Channels:
+ *   1. Telegram: if settings `admin_tg_bot_token` + `admin_tg_chat_id` are configured,
+ *      sends a message via HTTPS to the Bot API. No grammy bot instance needed.
+ *   2. (Future) Inbox / email
+ *
+ * Events handled:
+ *   - platform-budget.soft-alert → 80% of monthly platform limit
+ *   - platform-budget.hard-stop  → 100% — all org agents paused
+ *   - budget.soft-alert          → per-agent 80%
+ *   - budget.hard-stop           → per-agent 100%, agent paused
+ *   - agent.pause (reason=BUDGET_EXCEEDED) → fallback, covers runtime inline path
+ */
+@Injectable()
+export class BudgetNotificationsService {
+  private readonly logger = new Logger(BudgetNotificationsService.name);
+
+  constructor(
+    private settings: SettingsService,
+    private prisma: PrismaService,
+  ) {}
+
+  @OnEvent('platform-budget.soft-alert')
+  async onPlatformSoftAlert(payload: { orgId: string; spendUsd: number; limitUsd: number; percent: number }) {
+    const text = [
+      '⚠️ *Platform Budget — Soft Alert*',
+      `Monthly spend reached *${payload.percent.toFixed(1)}%* of the platform limit.`,
+      `Spend: *$${payload.spendUsd.toFixed(2)}* / *$${payload.limitUsd.toFixed(2)}*`,
+      '',
+      'Still running, but approaching the cap.',
+      '[Open Budgets](https://survival.agems.ai/budgets)',
+    ].join('\n');
+    await this.sendTelegram(payload.orgId, text);
+  }
+
+  @OnEvent('platform-budget.hard-stop')
+  async onPlatformHardStop(payload: { orgId: string; spendUsd: number; limitUsd: number }) {
+    const text = [
+      '🛑 *Platform Budget — HARD STOP*',
+      `Monthly platform limit exceeded. *All agents are paused.*`,
+      `Spend: *$${payload.spendUsd.toFixed(2)}* / *$${payload.limitUsd.toFixed(2)}*`,
+      '',
+      'Raise the limit or reset the budget to resume.',
+      '[Open Budgets](https://survival.agems.ai/budgets)',
+    ].join('\n');
+    await this.sendTelegram(payload.orgId, text);
+  }
+
+  @OnEvent('budget.soft-alert')
+  async onAgentSoftAlert(payload: { budgetId: string; agentId: string; agentName: string; spendUsd: number; limitUsd: number; percent: number }) {
+    const orgId = await this.lookupOrgByAgent(payload.agentId);
+    if (!orgId) return;
+    const text = [
+      `⚠️ *Agent Budget — Soft Alert*`,
+      `*${payload.agentName}* reached *${payload.percent.toFixed(1)}%* of monthly budget.`,
+      `Spend: *$${payload.spendUsd.toFixed(2)}* / *$${payload.limitUsd.toFixed(2)}*`,
+      '[Open Budgets](https://survival.agems.ai/budgets)',
+    ].join('\n');
+    await this.sendTelegram(orgId, text);
+  }
+
+  @OnEvent('budget.hard-stop')
+  async onAgentHardStop(payload: { budgetId: string; agentId: string; agentName: string; spendUsd: number; limitUsd: number }) {
+    const orgId = await this.lookupOrgByAgent(payload.agentId);
+    if (!orgId) return;
+    const text = [
+      `🛑 *Agent Budget — HARD STOP*`,
+      `*${payload.agentName}* exceeded its monthly budget and is paused.`,
+      `Spend: *$${payload.spendUsd.toFixed(2)}* / *$${payload.limitUsd.toFixed(2)}*`,
+      '[Open Budgets](https://survival.agems.ai/budgets)',
+    ].join('\n');
+    await this.sendTelegram(orgId, text);
+  }
+
+  /** Proactive cost-spike alert from TaskScheduler.runSpikeAlertScan. */
+  @OnEvent('budget.spike-detected')
+  async onSpikeDetected(payload: {
+    orgId: string;
+    date: string;
+    cost: number;
+    multiplier: number;
+    severity: 'minor' | 'major' | 'severe';
+    message: string;
+  }) {
+    const icon = payload.severity === 'severe' ? '🚨' : payload.severity === 'major' ? '⚠️' : 'ℹ️';
+    const text = [
+      `${icon} *Cost Spike Detected — ${payload.severity}*`,
+      `Day: *${payload.date}*`,
+      `Spend: *$${payload.cost.toFixed(2)}* (*${payload.multiplier.toFixed(1)}×* the 14-day rolling median)`,
+      '',
+      'Investigate whether an agent is in a loop or a tool is misbehaving.',
+      '[Open Budgets](https://survival.agems.ai/budgets)',
+    ].join('\n');
+    await this.sendTelegram(payload.orgId, text);
+  }
+
+  private async lookupOrgByAgent(agentId: string): Promise<string | null> {
+    const agent = await this.prisma.agent.findUnique({ where: { id: agentId }, select: { orgId: true } });
+    return agent?.orgId ?? null;
+  }
+
+  /**
+   * Send a Markdown message to the admin Telegram chat.
+   * Uses settings keys `admin_tg_bot_token` and `admin_tg_chat_id` (scoped to org).
+   * Silently skips if either is missing.
+   */
+  private async sendTelegram(orgId: string, text: string): Promise<void> {
+    try {
+      const [token, chatId] = await Promise.all([
+        this.settings.get('admin_tg_bot_token', orgId),
+        this.settings.get('admin_tg_chat_id', orgId),
+      ]);
+      if (!token || !chatId) return;
+
+      const url = `https://api.telegram.org/bot${token}/sendMessage`;
+      const body = {
+        chat_id: chatId,
+        text,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true,
+      };
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const errText = await res.text().catch(() => '<no body>');
+        this.logger.warn(`Telegram notification failed (${res.status}): ${errText.slice(0, 200)}`);
+      }
+    } catch (err) {
+      this.logger.error(`Failed to send Telegram notification: ${(err as Error).message}`);
+    }
+  }
+}

--- a/apps/api/src/modules/budgets/budget-reset.scheduler.ts
+++ b/apps/api/src/modules/budgets/budget-reset.scheduler.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaService } from '../../config/prisma.service';
+import { PlatformBudgetsService } from './platform-budgets.service';
+
+/**
+ * BudgetResetScheduler — periodically auto-clears hard_stop_triggered on PlatformBudget rows
+ * when the window that originally tripped it has rolled over (new hour / new day / new month).
+ *
+ * Why: hard_stop_triggered is a single boolean. If it tripped because of HOURLY overshoot at
+ * 14:59, an admin shouldn't have to manually un-stick it at 15:00 — the hourly window is fresh
+ * and spend is back to $0 in that window. Same logic for daily/monthly rollover.
+ *
+ * Implementation: every 60s walk all rows with hard_stop_triggered=true and call checkLimit
+ * with the flag ignored. If no window is currently over-budget, clear the flag and record a
+ * MANUAL_OVERRIDE incident (so audit trail shows it was an auto-reset).
+ *
+ * The 60s tick is cheap because the table has one row per org and the typical query plan is
+ * an index lookup on org_id.
+ */
+@Injectable()
+export class BudgetResetScheduler implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(BudgetResetScheduler.name);
+  private timer: NodeJS.Timeout | null = null;
+  private readonly intervalMs = 60_000;
+
+  constructor(
+    private prisma: PrismaService,
+    private platformBudgets: PlatformBudgetsService,
+  ) {}
+
+  onModuleInit() {
+    this.timer = setInterval(() => this.tick().catch((err) => this.logger.error(err)), this.intervalMs);
+    this.logger.log(`Budget reset scheduler started (${this.intervalMs / 1000}s interval)`);
+  }
+
+  onModuleDestroy() {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  /** Walk all stuck rows; clear hard_stop_triggered if current windows are no longer over-budget. */
+  private async tick() {
+    const stuck = await this.prisma.platformBudget.findMany({
+      where: { hardStopTriggered: true },
+      select: { id: true, orgId: true, currentSpendUsd: true, monthlyLimitUsd: true },
+    });
+    if (stuck.length === 0) return;
+
+    for (const pb of stuck) {
+      try {
+        // Temporarily ignore the flag to compute fresh window state
+        const breakdown = await this.platformBudgets.getSpendBreakdown(pb.orgId);
+        const stillOver =
+          (breakdown.hourly.limit !== null && breakdown.hourly.limit > 0 && breakdown.hourly.spend >= breakdown.hourly.limit) ||
+          (breakdown.daily.limit !== null && breakdown.daily.limit > 0 && breakdown.daily.spend >= breakdown.daily.limit) ||
+          (breakdown.monthly.limit !== null && breakdown.monthly.limit > 0 && breakdown.monthly.spend >= breakdown.monthly.limit);
+
+        if (!stillOver) {
+          await this.prisma.platformBudget.update({
+            where: { id: pb.id },
+            data: { hardStopTriggered: false, alertSent: false },
+          });
+          await this.prisma.platformBudgetIncident.create({
+            data: {
+              platformBudgetId: pb.id,
+              type: 'MANUAL_OVERRIDE',
+              scope: 'MONTHLY',
+              message: 'Auto-reset: all windows under their limits after rollover.',
+              spendUsd: breakdown.monthly.spend,
+              limitUsd: breakdown.monthly.limit ?? 0,
+            },
+          });
+          this.logger.log(`Cleared hard_stop_triggered for org=${pb.orgId} (windows back under limit)`);
+        }
+      } catch (err) {
+        this.logger.error(`Auto-reset failed for org=${pb.orgId}: ${(err as Error).message}`);
+      }
+    }
+  }
+}

--- a/apps/api/src/modules/budgets/budgets.controller.ts
+++ b/apps/api/src/modules/budgets/budgets.controller.ts
@@ -15,6 +15,8 @@ export class BudgetsController {
     @Body() body: {
       agentId: string;
       monthlyLimitUsd: number;
+      dailyLimitUsd?: number | null;
+      hourlyLimitUsd?: number | null;
       periodStart?: string;
       periodEnd?: string;
       softAlertPercent?: number;
@@ -59,6 +61,8 @@ export class BudgetsController {
     @Param('id') id: string,
     @Body() body: {
       monthlyLimitUsd?: number;
+      dailyLimitUsd?: number | null;
+      hourlyLimitUsd?: number | null;
       softAlertPercent?: number;
       hardStopEnabled?: boolean;
       metadata?: any;

--- a/apps/api/src/modules/budgets/budgets.module.ts
+++ b/apps/api/src/modules/budgets/budgets.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
 import { BudgetsController } from './budgets.controller';
 import { BudgetsService } from './budgets.service';
+import { PlatformBudgetsController } from './platform-budgets.controller';
+import { PlatformBudgetsService } from './platform-budgets.service';
+import { BudgetNotificationsService } from './budget-notifications.service';
+import { BudgetResetScheduler } from './budget-reset.scheduler';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
-  controllers: [BudgetsController],
-  providers: [BudgetsService],
-  exports: [BudgetsService],
+  imports: [SettingsModule],
+  controllers: [BudgetsController, PlatformBudgetsController],
+  providers: [BudgetsService, PlatformBudgetsService, BudgetNotificationsService, BudgetResetScheduler],
+  exports: [BudgetsService, PlatformBudgetsService],
 })
 export class BudgetsModule {}

--- a/apps/api/src/modules/budgets/budgets.service.ts
+++ b/apps/api/src/modules/budgets/budgets.service.ts
@@ -14,6 +14,8 @@ export class BudgetsService {
     input: {
       agentId: string;
       monthlyLimitUsd: number;
+      dailyLimitUsd?: number | null;
+      hourlyLimitUsd?: number | null;
       periodStart?: string;
       periodEnd?: string;
       softAlertPercent?: number;
@@ -40,6 +42,8 @@ export class BudgetsService {
       data: {
         agentId: input.agentId,
         monthlyLimitUsd: input.monthlyLimitUsd,
+        dailyLimitUsd: input.dailyLimitUsd ?? null,
+        hourlyLimitUsd: input.hourlyLimitUsd ?? null,
         currentSpendUsd: 0,
         periodStart,
         periodEnd,
@@ -101,6 +105,8 @@ export class BudgetsService {
     id: string,
     input: {
       monthlyLimitUsd?: number;
+      dailyLimitUsd?: number | null;
+      hourlyLimitUsd?: number | null;
       softAlertPercent?: number;
       hardStopEnabled?: boolean;
       metadata?: any;
@@ -114,6 +120,8 @@ export class BudgetsService {
       where: { id },
       data: {
         ...(input.monthlyLimitUsd !== undefined && { monthlyLimitUsd: input.monthlyLimitUsd }),
+        ...(input.dailyLimitUsd !== undefined && { dailyLimitUsd: input.dailyLimitUsd }),
+        ...(input.hourlyLimitUsd !== undefined && { hourlyLimitUsd: input.hourlyLimitUsd }),
         ...(input.softAlertPercent !== undefined && { softAlertPercent: input.softAlertPercent }),
         ...(input.hardStopEnabled !== undefined && { hardStopEnabled: input.hardStopEnabled }),
         ...(input.metadata !== undefined && { metadata: input.metadata as any }),
@@ -377,13 +385,13 @@ export class BudgetsService {
     const totalCost = executions.reduce((s, e) => s + (e.costUsd ?? 0), 0);
     const totalTokens = executions.reduce((s, e) => s + (e.tokensUsed ?? 0), 0);
 
-    // Burn-rate forecast. Open-source build has no org-wide cap (PlatformBudget
-    // is a managed-platform feature), so monthlyLimitUsd is null — forecast
-    // still returns avgDailyBurn / recentDailyBurn / trend / spikes.
+    // Burn-rate forecast against the platform budget (the org-wide cap).
+    // Per-agent forecasts are caller's job — they have the AgentBudget row.
+    const platformBudget = await this.prisma.platformBudget.findUnique({ where: { orgId } });
     const forecast = buildForecast({
       timeline: timeline.map(b => ({ date: b.date, cost: b.cost })),
-      monthlyLimitUsd: null,
-      alreadySpentUsd: 0,
+      monthlyLimitUsd: platformBudget?.monthlyLimitUsd ?? null,
+      alreadySpentUsd: platformBudget?.currentSpendUsd ?? 0,
     });
 
     return { timeline, agentBreakdown, totalCost, totalTokens, totalExecutions: executions.length, period, days, forecast };

--- a/apps/api/src/modules/budgets/platform-budgets.controller.ts
+++ b/apps/api/src/modules/budgets/platform-budgets.controller.ts
@@ -1,0 +1,61 @@
+import { Controller, Get, Put, Post, Body, Query, Request } from '@nestjs/common';
+import { PlatformBudgetsService } from './platform-budgets.service';
+import { Roles } from '../../common/decorators/roles.decorator';
+import type { RequestUser } from '../../common/types';
+
+@Controller('platform-budget')
+export class PlatformBudgetsController {
+  constructor(private service: PlatformBudgetsService) {}
+
+  /** Current platform budget for caller's org (null if not configured) */
+  @Get()
+  async get(@Request() req: { user: RequestUser }) {
+    const budget = await this.service.findByOrg(req.user.orgId);
+    const breakdown = await this.service.getSpendBreakdown(req.user.orgId);
+    return { budget, breakdown };
+  }
+
+  /** Live spend breakdown (hourly / daily / monthly + limits) */
+  @Get('breakdown')
+  getBreakdown(@Request() req: { user: RequestUser }) {
+    return this.service.getSpendBreakdown(req.user.orgId);
+  }
+
+  /** Create or update platform budget (MANAGER+) */
+  @Put()
+  @Roles('MANAGER')
+  upsert(
+    @Body() body: {
+      hourlyLimitUsd?: number | null;
+      dailyLimitUsd?: number | null;
+      monthlyLimitUsd?: number | null;
+      softAlertPercent?: number;
+      hardStopEnabled?: boolean;
+      periodStart?: string;
+      periodEnd?: string;
+      metadata?: any;
+    },
+    @Request() req: { user: RequestUser },
+  ) {
+    return this.service.upsert(req.user.orgId, body, req.user.id);
+  }
+
+  /** Manual monthly reset (MANAGER+) */
+  @Post('reset')
+  @Roles('MANAGER')
+  reset(
+    @Body() body: { periodStart?: string; periodEnd?: string },
+    @Request() req: { user: RequestUser },
+  ) {
+    return this.service.reset(req.user.orgId, body, req.user.id);
+  }
+
+  /** Incident history */
+  @Get('incidents')
+  getIncidents(
+    @Query() filters: { page?: string; pageSize?: string },
+    @Request() req: { user: RequestUser },
+  ) {
+    return this.service.getIncidents(req.user.orgId, filters);
+  }
+}

--- a/apps/api/src/modules/budgets/platform-budgets.service.ts
+++ b/apps/api/src/modules/budgets/platform-budgets.service.ts
@@ -1,0 +1,348 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { PrismaService } from '../../config/prisma.service';
+
+export type BudgetWindow = 'HOURLY' | 'DAILY' | 'MONTHLY';
+
+export interface PlatformBudgetCheckResult {
+  blocked: boolean;
+  reason?: string;
+  window?: BudgetWindow;
+  spendUsd?: number;
+  limitUsd?: number;
+  percent?: number;
+}
+
+/**
+ * PlatformBudgetsService — org-wide budget limits with higher priority than agent limits.
+ *
+ * Semantics:
+ *  - One PlatformBudget row per org (unique org_id).
+ *  - Three independent windows: hourly, daily, monthly. Each nullable — NULL means no platform cap.
+ *  - Hourly/daily spend is computed on-the-fly from agent_executions (source of truth).
+ *  - Monthly spend is tracked in current_spend_usd and incremented via recordSpend().
+ *  - If hard_stop_triggered=true OR any active window's spend ≥ its limit, the platform blocks
+ *    ALL agent executions in the org (checked before agent-level limits in runtime.service.ts).
+ */
+@Injectable()
+export class PlatformBudgetsService {
+  constructor(
+    private prisma: PrismaService,
+    private events: EventEmitter2,
+  ) {}
+
+  /** Get the platform budget for an org (null if none configured) */
+  async findByOrg(orgId: string) {
+    return this.prisma.platformBudget.findUnique({
+      where: { orgId },
+      include: {
+        incidents: { orderBy: { createdAt: 'desc' }, take: 20 },
+      },
+    });
+  }
+
+  /** Compute current spend for all three windows (hourly + daily from executions, monthly from counter) */
+  async getSpendBreakdown(orgId: string) {
+    const now = new Date();
+    const hourAgo = new Date(now.getTime() - 3600_000);
+    const todayStart = new Date(now);
+    todayStart.setHours(0, 0, 0, 0);
+
+    const pb = await this.prisma.platformBudget.findUnique({ where: { orgId } });
+
+    const [hourly, daily] = await Promise.all([
+      this.prisma.agentExecution.aggregate({
+        where: { agent: { orgId }, startedAt: { gte: hourAgo } },
+        _sum: { costUsd: true },
+      }),
+      this.prisma.agentExecution.aggregate({
+        where: { agent: { orgId }, startedAt: { gte: todayStart } },
+        _sum: { costUsd: true },
+      }),
+    ]);
+
+    const hourlySpend = hourly._sum.costUsd ?? 0;
+    const dailySpend = daily._sum.costUsd ?? 0;
+    const monthlySpend = pb?.currentSpendUsd ?? 0;
+
+    return {
+      hourly: { spend: hourlySpend, limit: pb?.hourlyLimitUsd ?? null },
+      daily: { spend: dailySpend, limit: pb?.dailyLimitUsd ?? null },
+      monthly: {
+        spend: monthlySpend,
+        limit: pb?.monthlyLimitUsd ?? null,
+        periodStart: pb?.periodStart ?? null,
+        periodEnd: pb?.periodEnd ?? null,
+      },
+      hardStopTriggered: pb?.hardStopTriggered ?? false,
+      softAlertPercent: pb?.softAlertPercent ?? 80,
+    };
+  }
+
+  /**
+   * Pre-execution platform gate. Called BEFORE the agent-level check.
+   * Returns { blocked: true, reason } if any active platform window is exceeded.
+   */
+  async checkLimit(orgId: string): Promise<PlatformBudgetCheckResult> {
+    const pb = await this.prisma.platformBudget.findUnique({ where: { orgId } });
+    if (!pb) return { blocked: false };
+
+    // Hard stop flag overrides everything until manually cleared/reset
+    if (pb.hardStopTriggered) {
+      return {
+        blocked: true,
+        reason: 'Platform hard stop is active. Raise limits or reset the platform budget.',
+        window: 'MONTHLY',
+        spendUsd: pb.currentSpendUsd,
+        limitUsd: pb.monthlyLimitUsd ?? 0,
+      };
+    }
+
+    const breakdown = await this.getSpendBreakdown(orgId);
+    const windows: Array<{ name: BudgetWindow; spend: number; limit: number | null }> = [
+      { name: 'HOURLY',  spend: breakdown.hourly.spend,  limit: breakdown.hourly.limit },
+      { name: 'DAILY',   spend: breakdown.daily.spend,   limit: breakdown.daily.limit },
+      { name: 'MONTHLY', spend: breakdown.monthly.spend, limit: breakdown.monthly.limit },
+    ];
+
+    for (const w of windows) {
+      if (w.limit !== null && w.limit > 0 && w.spend >= w.limit) {
+        return {
+          blocked: true,
+          reason: `Platform ${w.name.toLowerCase()} budget reached ($${w.spend.toFixed(2)} / $${w.limit.toFixed(2)}).`,
+          window: w.name,
+          spendUsd: w.spend,
+          limitUsd: w.limit,
+          percent: (w.spend / w.limit) * 100,
+        };
+      }
+    }
+
+    return { blocked: false };
+  }
+
+  /** Create or update the platform budget for an org (upsert — one row per org) */
+  async upsert(
+    orgId: string,
+    input: {
+      hourlyLimitUsd?: number | null;
+      dailyLimitUsd?: number | null;
+      monthlyLimitUsd?: number | null;
+      softAlertPercent?: number;
+      hardStopEnabled?: boolean;
+      periodStart?: string;
+      periodEnd?: string;
+      metadata?: any;
+    },
+    userId: string,
+  ) {
+    const now = new Date();
+    const defaultStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const defaultEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+
+    const existing = await this.prisma.platformBudget.findUnique({ where: { orgId } });
+
+    const data = {
+      ...(input.hourlyLimitUsd !== undefined && { hourlyLimitUsd: input.hourlyLimitUsd }),
+      ...(input.dailyLimitUsd !== undefined && { dailyLimitUsd: input.dailyLimitUsd }),
+      ...(input.monthlyLimitUsd !== undefined && { monthlyLimitUsd: input.monthlyLimitUsd }),
+      ...(input.softAlertPercent !== undefined && { softAlertPercent: input.softAlertPercent }),
+      ...(input.hardStopEnabled !== undefined && { hardStopEnabled: input.hardStopEnabled }),
+      ...(input.metadata !== undefined && { metadata: input.metadata as any }),
+      ...(input.periodStart && { periodStart: new Date(input.periodStart) }),
+      ...(input.periodEnd && { periodEnd: new Date(input.periodEnd) }),
+    };
+
+    let budget;
+    if (existing) {
+      // If any monthly limit raised above current spend, clear hard stop
+      const newMonthly = input.monthlyLimitUsd ?? existing.monthlyLimitUsd;
+      const clearStop =
+        existing.hardStopTriggered &&
+        newMonthly !== null &&
+        newMonthly !== undefined &&
+        newMonthly > existing.currentSpendUsd;
+
+      budget = await this.prisma.platformBudget.update({
+        where: { orgId },
+        data: {
+          ...data,
+          ...(clearStop && { hardStopTriggered: false, alertSent: false }),
+        },
+      });
+
+      if (clearStop) {
+        await this.prisma.platformBudgetIncident.create({
+          data: {
+            platformBudgetId: budget.id,
+            type: 'MANUAL_OVERRIDE',
+            scope: 'MONTHLY',
+            message: `Monthly limit raised to $${newMonthly}; hard stop cleared`,
+            spendUsd: existing.currentSpendUsd,
+            limitUsd: newMonthly,
+          },
+        });
+      }
+    } else {
+      budget = await this.prisma.platformBudget.create({
+        data: {
+          orgId,
+          hourlyLimitUsd: input.hourlyLimitUsd ?? null,
+          dailyLimitUsd: input.dailyLimitUsd ?? null,
+          monthlyLimitUsd: input.monthlyLimitUsd ?? null,
+          softAlertPercent: input.softAlertPercent ?? 80,
+          hardStopEnabled: input.hardStopEnabled ?? true,
+          periodStart: input.periodStart ? new Date(input.periodStart) : defaultStart,
+          periodEnd: input.periodEnd ? new Date(input.periodEnd) : defaultEnd,
+          metadata: input.metadata ?? null,
+          currentSpendUsd: 0,
+        },
+      });
+    }
+
+    this.events.emit('audit.create', {
+      actorType: 'HUMAN', actorId: userId, action: existing ? 'UPDATE' : 'CREATE',
+      resourceType: 'platform_budget', resourceId: budget.id, orgId,
+    });
+
+    return budget;
+  }
+
+  /**
+   * Increment monthly spend counter and check all three windows for soft-alert / hard-stop.
+   * Called after every agent execution.
+   *
+   * Reliability: monthly counter increment uses an atomic SQL `UPDATE … SET col = col + $n`
+   * so concurrent recordSpend() calls do not lose updates. Hourly/daily spend is recomputed
+   * fresh from agent_executions to catch overshoots from parallel executions that all passed
+   * the gate just before any of them reported cost.
+   */
+  async recordSpend(orgId: string, amount: number, description?: string) {
+    if (amount <= 0) return null;
+    const pb = await this.prisma.platformBudget.findUnique({ where: { orgId } });
+    if (!pb) return null; // No platform budget configured — nothing to track
+
+    // Atomic increment of monthly counter — `UPDATE col = col + $n` is safe under concurrency.
+    await this.prisma.$executeRaw`UPDATE platform_budgets SET current_spend_usd = current_spend_usd + ${amount}, updated_at = NOW() WHERE id = ${pb.id}`;
+    const afterMonthly = (await this.prisma.platformBudget.findUnique({ where: { id: pb.id } }))!;
+
+    // Soft alert on monthly
+    const monthlyLimit = afterMonthly.monthlyLimitUsd;
+    const monthlyPct = monthlyLimit && monthlyLimit > 0 ? (afterMonthly.currentSpendUsd / monthlyLimit) * 100 : 0;
+    if (monthlyLimit && monthlyPct >= afterMonthly.softAlertPercent && !afterMonthly.alertSent) {
+      await this.prisma.platformBudget.update({ where: { id: pb.id }, data: { alertSent: true } });
+      await this.prisma.platformBudgetIncident.create({
+        data: {
+          platformBudgetId: pb.id,
+          type: 'SOFT_ALERT',
+          scope: 'MONTHLY',
+          message: description
+            ? `Platform monthly soft alert at ${monthlyPct.toFixed(1)}%: ${description}`
+            : `Platform monthly spend reached ${monthlyPct.toFixed(1)}% of $${monthlyLimit} limit`,
+          spendUsd: afterMonthly.currentSpendUsd,
+          limitUsd: monthlyLimit,
+        },
+      });
+      this.events.emit('platform-budget.soft-alert', {
+        orgId, scope: 'MONTHLY', spendUsd: afterMonthly.currentSpendUsd, limitUsd: monthlyLimit, percent: monthlyPct,
+      });
+    }
+
+    // Re-check all three windows for hard-stop (covers race-condition overshoot from parallel
+    // executions where every one passed checkLimit before the first recordSpend landed).
+    if (afterMonthly.hardStopEnabled && !afterMonthly.hardStopTriggered) {
+      const breakdown = await this.getSpendBreakdown(orgId);
+      const windows: Array<{ scope: BudgetWindow; spend: number; limit: number | null }> = [
+        { scope: 'HOURLY',  spend: breakdown.hourly.spend,  limit: breakdown.hourly.limit },
+        { scope: 'DAILY',   spend: breakdown.daily.spend,   limit: breakdown.daily.limit },
+        { scope: 'MONTHLY', spend: breakdown.monthly.spend, limit: breakdown.monthly.limit },
+      ];
+      for (const w of windows) {
+        if (w.limit !== null && w.limit > 0 && w.spend >= w.limit) {
+          await this.prisma.platformBudget.update({
+            where: { id: pb.id },
+            data: { hardStopTriggered: true },
+          });
+          await this.prisma.platformBudgetIncident.create({
+            data: {
+              platformBudgetId: pb.id,
+              type: 'HARD_STOP',
+              scope: w.scope,
+              message: description
+                ? `Platform ${w.scope.toLowerCase()} hard stop: ${description}`
+                : `Platform ${w.scope.toLowerCase()} spend ($${w.spend.toFixed(2)}) exceeded limit ($${w.limit.toFixed(2)}) — all agents paused`,
+              spendUsd: w.spend,
+              limitUsd: w.limit,
+            },
+          });
+          this.events.emit('platform-budget.hard-stop', {
+            orgId, scope: w.scope, spendUsd: w.spend, limitUsd: w.limit,
+          });
+          break; // One hard stop is enough; further windows would just be duplicate incidents
+        }
+      }
+    }
+
+    return afterMonthly;
+  }
+
+  /** Manual monthly reset (clears counter, alerts, hard stop) */
+  async reset(orgId: string, input: { periodStart?: string; periodEnd?: string }, userId: string) {
+    const pb = await this.prisma.platformBudget.findUnique({ where: { orgId } });
+    if (!pb) throw new NotFoundException('Platform budget not configured');
+
+    await this.prisma.platformBudgetIncident.create({
+      data: {
+        platformBudgetId: pb.id,
+        type: 'BUDGET_RESET',
+        scope: 'MONTHLY',
+        message: `Platform budget reset. Previous spend: $${pb.currentSpendUsd} / $${pb.monthlyLimitUsd ?? 'unlimited'}`,
+        spendUsd: pb.currentSpendUsd,
+        limitUsd: pb.monthlyLimitUsd ?? 0,
+      },
+    });
+
+    const now = new Date();
+    const updated = await this.prisma.platformBudget.update({
+      where: { orgId },
+      data: {
+        currentSpendUsd: 0,
+        alertSent: false,
+        hardStopTriggered: false,
+        periodStart: input.periodStart ? new Date(input.periodStart)
+          : new Date(now.getFullYear(), now.getMonth(), 1),
+        periodEnd: input.periodEnd ? new Date(input.periodEnd)
+          : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59),
+      },
+    });
+
+    this.events.emit('audit.create', {
+      actorType: 'HUMAN', actorId: userId, action: 'UPDATE',
+      resourceType: 'platform_budget', resourceId: updated.id, orgId,
+      details: { action: 'PLATFORM_BUDGET_RESET' },
+    });
+
+    return updated;
+  }
+
+  /** Incident history */
+  async getIncidents(orgId: string, filters: { page?: string; pageSize?: string }) {
+    const pb = await this.prisma.platformBudget.findUnique({ where: { orgId } });
+    if (!pb) return { data: [], total: 0, page: 1, pageSize: 20, totalPages: 0 };
+
+    const page = Number(filters.page) || 1;
+    const pageSize = Number(filters.pageSize) || 20;
+
+    const [data, total] = await Promise.all([
+      this.prisma.platformBudgetIncident.findMany({
+        where: { platformBudgetId: pb.id },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.platformBudgetIncident.count({ where: { platformBudgetId: pb.id } }),
+    ]);
+
+    return { data, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+  }
+}

--- a/apps/api/src/modules/runtime/runtime.service.ts
+++ b/apps/api/src/modules/runtime/runtime.service.ts
@@ -18,6 +18,7 @@ import { decryptJson } from '../../common/crypto.util';
 import { RedisLockService } from '../../common/redis-lock.service';
 import { BrowserService } from './browser.service';
 import { buildExecutionAttribution } from './cost-attribution';
+import { PlatformBudgetsService } from '../budgets/platform-budgets.service';
 import { rankMemories } from './memory-search';
 
 @Injectable()
@@ -96,6 +97,7 @@ export class RuntimeService {
     private prisma: PrismaService,
     private agentsService: AgentsService,
     private settings: SettingsService,
+    private platformBudgets: PlatformBudgetsService,
     private n8n: N8nService,
     private comms: CommsService,
     private events: EventEmitter2,
@@ -1036,6 +1038,19 @@ Respond as ${currentAgent.name}. Be concise and professional. Write in the same 
         return { text: noKeyMessage, toolCalls: [], tokensUsed: 0, costUsd: 0, waitingForApproval: false, thinking: [] as string[], iterations: 0, loopDetected: false, executionId: execution.id };
       }
 
+      // ═══════════════════════════════════════════════════
+      // PLATFORM BUDGET GATE — org-wide cap, higher priority than per-agent
+      // ═══════════════════════════════════════════════════
+      const platformCheck = await this.platformBudgets.checkLimit(agent.orgId);
+      if (platformCheck.blocked) {
+        this.logger.warn(`Agent ${agent.name} blocked by platform budget: ${platformCheck.reason}`);
+        await this.prisma.agentExecution.update({
+          where: { id: execution.id },
+          data: { status: 'COMPLETED', output: { text: platformCheck.reason }, endedAt: new Date() },
+        });
+        return { text: platformCheck.reason!, toolCalls: [], tokensUsed: 0, costUsd: 0, waitingForApproval: false, thinking: [] as string[], iterations: 0, loopDetected: false, executionId: execution.id };
+      }
+
       // Check budget limits before execution (hourly + daily)
       const agentLlmConfig = (agent.llmConfig as any) || {};
       const settingsService = this.settings;
@@ -1327,6 +1342,15 @@ Respond as ${currentAgent.name}. Be concise and professional. Write in the same 
           },
         });
 
+        try {
+          const __cost = this.estimateCost(agent.llmProvider, result.tokensUsed);
+          if (__cost > 0) {
+            await this.platformBudgets.recordSpend(agent.orgId, __cost, `${agent.name} execution`);
+          }
+        } catch (err) {
+          this.logger.error(`Platform budget recordSpend failed: ${(err as Error).message}`);
+        }
+
         return { executionId: execution.id, ...result, waitingForApproval: true };
       }
 
@@ -1346,6 +1370,16 @@ Respond as ${currentAgent.name}. Be concise and professional. Write in the same 
           endedAt: new Date(),
         },
       });
+
+      // Post-execution: increment platform monthly spend counter (drives soft-alert/hard-stop)
+      try {
+        const __cost = this.estimateCost(agent.llmProvider, result.tokensUsed);
+        if (__cost > 0) {
+          await this.platformBudgets.recordSpend(agent.orgId, __cost, `${agent.name} execution`);
+        }
+      } catch (err) {
+        this.logger.error(`Platform budget recordSpend failed: ${(err as Error).message}`);
+      }
 
       this.events.emit('audit.create', {
         actorType: 'AGENT',

--- a/apps/web/src/app/(dashboard)/budgets/page.tsx
+++ b/apps/web/src/app/(dashboard)/budgets/page.tsx
@@ -13,13 +13,255 @@ function spendColor(percent: number): string {
   return 'var(--success)';
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Platform Budget Card (org-wide limits, higher priority than agent limits)
+// ──────────────────────────────────────────────────────────────────────────
+
+function PlatformBudgetCard() {
+  const [data, setData] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState<{
+    hourlyLimitUsd: string;
+    dailyLimitUsd: string;
+    monthlyLimitUsd: string;
+    softAlertPercent: number;
+    hardStopEnabled: boolean;
+  }>({ hourlyLimitUsd: '', dailyLimitUsd: '', monthlyLimitUsd: '', softAlertPercent: 80, hardStopEnabled: true });
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await api.getPlatformBudget();
+      setData(res);
+      setForm({
+        hourlyLimitUsd: res.budget?.hourlyLimitUsd != null ? String(res.budget.hourlyLimitUsd) : '',
+        dailyLimitUsd: res.budget?.dailyLimitUsd != null ? String(res.budget.dailyLimitUsd) : '',
+        monthlyLimitUsd: res.budget?.monthlyLimitUsd != null ? String(res.budget.monthlyLimitUsd) : '',
+        softAlertPercent: res.budget?.softAlertPercent ?? 80,
+        hardStopEnabled: res.budget?.hardStopEnabled ?? true,
+      });
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const save = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const toNum = (s: string) => (s === '' ? null : parseFloat(s));
+      await api.upsertPlatformBudget({
+        hourlyLimitUsd: toNum(form.hourlyLimitUsd),
+        dailyLimitUsd: toNum(form.dailyLimitUsd),
+        monthlyLimitUsd: toNum(form.monthlyLimitUsd),
+        softAlertPercent: form.softAlertPercent,
+        hardStopEnabled: form.hardStopEnabled,
+      });
+      setEditing(false);
+      await load();
+    } catch (e: any) {
+      setError(e.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = async () => {
+    if (!confirm('Reset platform monthly spend to 0?')) return;
+    try {
+      await api.resetPlatformBudget();
+      await load();
+    } catch (e: any) {
+      alert(e.message || 'Failed to reset');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="mb-6 p-6 bg-[var(--card)] border border-[var(--border)] rounded-xl">
+        <p className="text-sm text-[var(--muted)]">Loading platform budget…</p>
+      </div>
+    );
+  }
+
+  const bd = data?.breakdown;
+  const windows = [
+    { key: 'hourly',  label: 'Hourly',  spend: bd?.hourly?.spend ?? 0,  limit: bd?.hourly?.limit  ?? null, tone: 'bg-blue-500/10 text-blue-400 border-blue-500/30' },
+    { key: 'daily',   label: 'Daily',   spend: bd?.daily?.spend ?? 0,   limit: bd?.daily?.limit   ?? null, tone: 'bg-purple-500/10 text-purple-400 border-purple-500/30' },
+    { key: 'monthly', label: 'Monthly', spend: bd?.monthly?.spend ?? 0, limit: bd?.monthly?.limit ?? null, tone: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30' },
+  ];
+
+  return (
+    <div className="mb-6 bg-[var(--card)] border-2 border-[var(--accent)]/40 rounded-2xl p-5 md:p-6">
+      <div className="flex items-start justify-between gap-4 mb-4 flex-wrap">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="px-2 py-0.5 rounded-md bg-[var(--accent)]/20 text-[var(--accent)] text-xs font-semibold uppercase tracking-wide">
+              Platform
+            </span>
+            <h2 className="text-xl font-bold">Organization Budget</h2>
+            {data?.breakdown?.hardStopTriggered && (
+              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-red-500/20 text-red-400 border border-red-500/30">
+                HARD STOP
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-[var(--muted)] mt-1">
+            Applies to all agents. <span className="font-medium">Higher priority than per-agent limits</span> — if exceeded, every agent in the org is blocked.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {!editing && (
+            <>
+              <button
+                onClick={() => setEditing(true)}
+                className="px-3 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--card-hover)] text-sm transition-colors"
+              >
+                {data?.budget ? 'Edit Limits' : 'Set Limits'}
+              </button>
+              {data?.budget && (
+                <button
+                  onClick={reset}
+                  className="px-3 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--card-hover)] text-sm transition-colors"
+                >
+                  Reset Monthly
+                </button>
+              )}
+            </>
+          )}
+          {editing && (
+            <>
+              <button
+                onClick={() => { setEditing(false); load(); }}
+                className="px-3 py-1.5 rounded-lg border border-[var(--border)] hover:bg-[var(--card-hover)] text-sm transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={save}
+                disabled={saving}
+                className="px-3 py-1.5 rounded-lg bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-sm font-medium transition-colors disabled:opacity-50"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-3 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">{error}</div>
+      )}
+
+      {!editing ? (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {windows.map((w) => {
+            const hasLimit = w.limit !== null && w.limit > 0;
+            const pct = hasLimit ? (w.spend / (w.limit as number)) * 100 : 0;
+            return (
+              <div key={w.key} className={`p-4 rounded-xl border ${w.tone}`}>
+                <div className="flex items-baseline justify-between mb-1">
+                  <span className="text-xs font-semibold uppercase tracking-wide">{w.label}</span>
+                  {hasLimit ? (
+                    <span className="text-xs opacity-80">{pct.toFixed(0)}%</span>
+                  ) : (
+                    <span className="text-xs opacity-60">no limit</span>
+                  )}
+                </div>
+                <div className="text-lg font-bold">
+                  {formatUsd(w.spend)}
+                  {hasLimit && <span className="text-sm font-normal opacity-70"> / {formatUsd(w.limit as number)}</span>}
+                </div>
+                {hasLimit && (
+                  <div className="w-full h-1.5 rounded-full bg-black/20 overflow-hidden mt-2">
+                    <div
+                      className="h-full rounded-full transition-all duration-300"
+                      style={{ width: `${Math.min(pct, 100)}%`, backgroundColor: spendColor(pct) }}
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
+            {[
+              { k: 'hourlyLimitUsd',  label: 'Hourly Limit (USD)',  step: '0.1', placeholder: 'e.g. 2.00' },
+              { k: 'dailyLimitUsd',   label: 'Daily Limit (USD)',   step: '1',   placeholder: 'e.g. 50' },
+              { k: 'monthlyLimitUsd', label: 'Monthly Limit (USD)', step: '10',  placeholder: 'e.g. 1000' },
+            ].map((f) => (
+              <div key={f.k}>
+                <label className="block text-xs font-medium mb-1 text-[var(--muted)]">{f.label}</label>
+                <input
+                  type="number"
+                  min="0"
+                  step={f.step}
+                  placeholder={f.placeholder}
+                  value={(form as any)[f.k]}
+                  onChange={(e) => setForm({ ...form, [f.k]: e.target.value } as any)}
+                  className="w-full px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-sm"
+                />
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-[var(--muted)] mb-3">Leave empty to remove the cap for that window.</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium mb-1">Soft Alert Threshold: {form.softAlertPercent}%</label>
+              <input
+                type="range"
+                min="0"
+                max="100"
+                value={form.softAlertPercent}
+                onChange={(e) => setForm({ ...form, softAlertPercent: parseInt(e.target.value) })}
+                className="w-full accent-[var(--accent)]"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">Hard Stop</p>
+                <p className="text-xs text-[var(--muted)]">Pause all agents when monthly limit exceeded</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setForm({ ...form, hardStopEnabled: !form.hardStopEnabled })}
+                className={`relative w-11 h-6 rounded-full transition-colors ${
+                  form.hardStopEnabled ? 'bg-[var(--accent)]' : 'bg-[var(--border)]'
+                }`}
+              >
+                <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white transition-transform ${
+                  form.hardStopEnabled ? 'translate-x-5' : 'translate-x-0'
+                }`} />
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Main page
+// ──────────────────────────────────────────────────────────────────────────
+
 export default function BudgetsPage() {
   const [budgets, setBudgets] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [summary, setSummary] = useState<any>(null);
   const [modalMode, setModalMode] = useState<'create' | 'edit' | null>(null);
   const [selectedBudget, setSelectedBudget] = useState<any>(null);
-  const [form, setForm] = useState({ agentId: '', monthlyLimitUsd: 100, dailyLimitUsd: 3, hourlyLimitUsd: 0.5, softAlertPercent: 80, hardStopEnabled: true });
+  const [form, setForm] = useState({ agentId: '', monthlyLimitUsd: 4, dailyLimitUsd: '', hourlyLimitUsd: '', softAlertPercent: 80, hardStopEnabled: true });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [agents, setAgents] = useState<any[]>([]);
@@ -48,21 +290,23 @@ export default function BudgetsPage() {
   useEffect(() => { loadData(); }, []);
 
   const openCreate = () => {
-    setForm({ agentId: '', monthlyLimitUsd: 100, dailyLimitUsd: 3, hourlyLimitUsd: 0.5, softAlertPercent: 80, hardStopEnabled: true });
+    setForm({ agentId: '', monthlyLimitUsd: 4, dailyLimitUsd: '', hourlyLimitUsd: '', softAlertPercent: 80, hardStopEnabled: true });
     setSelectedBudget(null);
     setError('');
     setModalMode('create');
   };
 
   const openEdit = (budget: any) => {
-    // Get daily/hourly from agent's llmConfig
-    const agent = agentMap.get(budget.agentId);
-    const lc = (agent?.llmConfig || {}) as any;
     setForm({
       agentId: budget.agentId,
       monthlyLimitUsd: budget.monthlyLimitUsd,
-      dailyLimitUsd: lc.dailyBudgetUsd ?? 3,
-      hourlyLimitUsd: lc.hourlyBudgetUsd ?? 0.5,
+      // Prefer new agent_budgets columns; fall back to legacy llm_config
+      dailyLimitUsd: budget.dailyLimitUsd != null ? String(budget.dailyLimitUsd)
+        : (agentMap.get(budget.agentId)?.llmConfig?.dailyBudgetUsd != null
+          ? String(agentMap.get(budget.agentId).llmConfig.dailyBudgetUsd) : ''),
+      hourlyLimitUsd: budget.hourlyLimitUsd != null ? String(budget.hourlyLimitUsd)
+        : (agentMap.get(budget.agentId)?.llmConfig?.hourlyBudgetUsd != null
+          ? String(agentMap.get(budget.agentId).llmConfig.hourlyBudgetUsd) : ''),
       softAlertPercent: budget.softAlertPercent ?? 80,
       hardStopEnabled: budget.hardStopEnabled ?? true,
     });
@@ -77,9 +321,13 @@ export default function BudgetsPage() {
     setSaving(true);
     setError('');
     try {
+      const toNum = (s: string | number) =>
+        typeof s === 'number' ? (s > 0 ? s : null) : (s === '' ? null : parseFloat(s));
       const budgetPayload = {
         agentId: form.agentId,
         monthlyLimitUsd: form.monthlyLimitUsd,
+        dailyLimitUsd: toNum(form.dailyLimitUsd),
+        hourlyLimitUsd: toNum(form.hourlyLimitUsd),
         softAlertPercent: form.softAlertPercent,
         hardStopEnabled: form.hardStopEnabled,
       };
@@ -87,14 +335,6 @@ export default function BudgetsPage() {
         await api.createBudget(budgetPayload);
       } else if (modalMode === 'edit' && selectedBudget) {
         await api.updateBudget(selectedBudget.id, budgetPayload);
-      }
-      // Save daily/hourly limits to agent's llmConfig
-      if (form.agentId) {
-        try {
-          const agentData = await api.getAgent(form.agentId);
-          const llmConfig = { ...(agentData.llmConfig || {}), dailyBudgetUsd: form.dailyLimitUsd, hourlyBudgetUsd: form.hourlyLimitUsd };
-          await api.updateAgent(form.agentId, { llmConfig });
-        } catch { /* silent */ }
       }
       setModalMode(null);
       loadData();
@@ -141,21 +381,24 @@ export default function BudgetsPage() {
       <div className="flex items-center justify-between mb-6 md:mb-8 flex-wrap gap-3">
         <div>
           <h1 className="text-2xl md:text-3xl font-bold">Budgets & Costs</h1>
-          <p className="text-[var(--muted)] mt-1 text-sm">Monitor and control agent spending</p>
+          <p className="text-[var(--muted)] mt-1 text-sm">Platform-wide cap + per-agent limits. Platform wins.</p>
         </div>
         <button
           onClick={openCreate}
           className="px-4 py-2 bg-[var(--accent)] hover:bg-[var(--accent-hover)] rounded-lg font-medium transition-colors text-sm"
         >
-          + New Budget
+          + New Agent Budget
         </button>
       </div>
 
-      {/* Summary Cards */}
+      {/* Platform Budget Card — top-priority cap on the whole org */}
+      <PlatformBudgetCard />
+
+      {/* Agent Summary Cards */}
       {summary && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
           <div className="p-5 bg-[var(--card)] border border-[var(--border)] rounded-xl">
-            <p className="text-xs text-[var(--muted)] uppercase tracking-wide mb-1">Total Monthly Limit</p>
+            <p className="text-xs text-[var(--muted)] uppercase tracking-wide mb-1">Total Monthly Limit (agents)</p>
             <p className="text-2xl font-bold">{formatUsd(summary.totalLimitUsd ?? summary.totalLimit ?? 0)}</p>
           </div>
           <div className="p-5 bg-[var(--card)] border border-[var(--border)] rounded-xl">
@@ -181,8 +424,8 @@ export default function BudgetsPage() {
       ) : budgets.length === 0 ? (
         <div className="text-center py-20 border border-dashed border-[var(--border)] rounded-xl">
           <p className="text-4xl mb-4">💰</p>
-          <p className="text-lg font-medium mb-2">No budgets configured</p>
-          <p className="text-[var(--muted)] mb-4">Set up spending limits for your agents</p>
+          <p className="text-lg font-medium mb-2">No per-agent budgets configured</p>
+          <p className="text-[var(--muted)] mb-4">Set up spending limits for individual agents</p>
           <button
             onClick={openCreate}
             className="px-4 py-2 bg-[var(--accent)] hover:bg-[var(--accent-hover)] rounded-lg font-medium transition-colors inline-block"
@@ -196,7 +439,7 @@ export default function BudgetsPage() {
           <div className="hidden md:grid grid-cols-12 gap-4 px-5 py-2 text-xs text-[var(--muted)] uppercase tracking-wide">
             <div className="col-span-2">Agent</div>
             <div className="col-span-3">Limits (hr / day / mo)</div>
-            <div className="col-span-3">Current Spend</div>
+            <div className="col-span-3">Monthly Spend</div>
             <div className="col-span-2">Alerts</div>
             <div className="col-span-2 text-right">Actions</div>
           </div>
@@ -205,6 +448,9 @@ export default function BudgetsPage() {
             const percent = budget.monthlyLimitUsd > 0 ? (budget.currentSpendUsd / budget.monthlyLimitUsd) * 100 : 0;
             const agent = agentMap.get(budget.agentId) || budget.agent;
             const agentName = agent?.name || budget.agentId;
+            // Prefer new agent_budgets cols; fall back to legacy llm_config
+            const h = budget.hourlyLimitUsd ?? (agent?.llmConfig as any)?.hourlyBudgetUsd ?? null;
+            const d = budget.dailyLimitUsd ?? (agent?.llmConfig as any)?.dailyBudgetUsd ?? null;
 
             return (
               <div key={budget.id}>
@@ -222,24 +468,17 @@ export default function BudgetsPage() {
 
                     {/* Limits: hourly / daily / monthly */}
                     <div className="col-span-3">
-                      {(() => {
-                        const lc = (agent?.llmConfig || {}) as any;
-                        const h = lc.hourlyBudgetUsd;
-                        const d = lc.dailyBudgetUsd;
-                        return (
-                          <div className="flex items-center gap-2 text-sm">
-                            <span className="px-2 py-0.5 rounded bg-blue-500/10 text-blue-400 text-xs font-mono" title="Hourly">
-                              {h ? `$${h}/h` : '—'}
-                            </span>
-                            <span className="px-2 py-0.5 rounded bg-purple-500/10 text-purple-400 text-xs font-mono" title="Daily">
-                              {d ? `$${d}/d` : '—'}
-                            </span>
-                            <span className="px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 text-xs font-mono" title="Monthly">
-                              {formatUsd(budget.monthlyLimitUsd)}/mo
-                            </span>
-                          </div>
-                        );
-                      })()}
+                      <div className="flex items-center gap-2 text-sm">
+                        <span className="px-2 py-0.5 rounded bg-blue-500/10 text-blue-400 text-xs font-mono" title="Hourly">
+                          {h != null ? `$${h}/h` : '—'}
+                        </span>
+                        <span className="px-2 py-0.5 rounded bg-purple-500/10 text-purple-400 text-xs font-mono" title="Daily">
+                          {d != null ? `$${d}/d` : '—'}
+                        </span>
+                        <span className="px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-400 text-xs font-mono" title="Monthly">
+                          {formatUsd(budget.monthlyLimitUsd)}/mo
+                        </span>
+                      </div>
                     </div>
 
                     {/* Spend + Progress */}
@@ -262,7 +501,7 @@ export default function BudgetsPage() {
                     {/* Alert Status */}
                     <div className="col-span-2">
                       <div className="flex flex-wrap gap-1">
-                        {budget.softAlertSent && (
+                        {budget.alertSent && (
                           <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-500/20 text-yellow-400">
                             Soft Alert
                           </span>
@@ -272,7 +511,7 @@ export default function BudgetsPage() {
                             Hard Stop
                           </span>
                         )}
-                        {!budget.softAlertSent && !budget.hardStopTriggered && (
+                        {!budget.alertSent && !budget.hardStopTriggered && (
                           <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-400">
                             OK
                           </span>
@@ -318,7 +557,7 @@ export default function BudgetsPage() {
                       <p className="text-sm text-[var(--muted)]">No incidents recorded</p>
                     ) : (
                       <div className="space-y-2 max-h-64 overflow-y-auto">
-                        {incidents.map((inc, idx) => (
+                        {incidents.map((inc: any, idx: number) => (
                           <div key={inc.id || idx} className="flex items-start gap-3 p-3 rounded-lg bg-[var(--bg)] border border-[var(--border)]">
                             <span className={`mt-0.5 px-2 py-0.5 rounded-full text-xs font-medium ${
                               inc.type === 'HARD_STOP' ? 'bg-red-500/20 text-red-400'
@@ -330,7 +569,7 @@ export default function BudgetsPage() {
                             <div className="flex-1 min-w-0">
                               <p className="text-sm">{inc.message}</p>
                               <div className="flex gap-4 mt-1 text-xs text-[var(--muted)]">
-                                {inc.amountUsd != null && <span>Amount: {formatUsd(inc.amountUsd)}</span>}
+                                {inc.spendUsd != null && <span>Spend: {formatUsd(inc.spendUsd)}</span>}
                                 {inc.limitUsd != null && <span>Limit: {formatUsd(inc.limitUsd)}</span>}
                               </div>
                             </div>
@@ -354,7 +593,7 @@ export default function BudgetsPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={() => setModalMode(null)}>
           <div className="bg-[var(--card)] border border-[var(--border)] rounded-2xl w-full max-w-md p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
             <h2 className="text-xl font-bold mb-5">
-              {modalMode === 'create' ? 'Create Budget' : 'Edit Budget'}
+              {modalMode === 'create' ? 'Create Agent Budget' : 'Edit Agent Budget'}
             </h2>
 
             {error && (
@@ -389,7 +628,7 @@ export default function BudgetsPage() {
                     min="0"
                     step="0.1"
                     value={form.hourlyLimitUsd}
-                    onChange={(e) => setForm({ ...form, hourlyLimitUsd: parseFloat(e.target.value) || 0 })}
+                    onChange={(e) => setForm({ ...form, hourlyLimitUsd: e.target.value })}
                     className="w-full px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-sm"
                     placeholder="0.50"
                   />
@@ -401,7 +640,7 @@ export default function BudgetsPage() {
                     min="0"
                     step="0.5"
                     value={form.dailyLimitUsd}
-                    onChange={(e) => setForm({ ...form, dailyLimitUsd: parseFloat(e.target.value) || 0 })}
+                    onChange={(e) => setForm({ ...form, dailyLimitUsd: e.target.value })}
                     className="w-full px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-sm"
                     placeholder="3.00"
                   />
@@ -419,7 +658,7 @@ export default function BudgetsPage() {
                   />
                 </div>
               </div>
-              <p className="text-xs text-[var(--muted)] -mt-2">Hourly and daily limits prevent overspending in short bursts. 0 = no limit.</p>
+              <p className="text-xs text-[var(--muted)] -mt-2">Empty = no limit for that window. Platform cap still applies on top.</p>
 
               {/* Soft Alert Percent */}
               <div>
@@ -445,7 +684,7 @@ export default function BudgetsPage() {
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm font-medium">Hard Stop</p>
-                  <p className="text-xs text-[var(--muted)]">Block agent when budget is exceeded</p>
+                  <p className="text-xs text-[var(--muted)]">Block agent when monthly budget is exceeded</p>
                 </div>
                 <button
                   type="button"

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -927,6 +927,64 @@ class ApiClient {
     return this.fetch<any>(`/agents/${agentId}/cost-stats?period=${period}&days=${days}`);
   }
 
+  // Platform Budget (org-wide limits with priority over agent limits)
+  getPlatformBudget() {
+    return this.fetch<{
+      budget: {
+        id: string;
+        orgId: string;
+        hourlyLimitUsd: number | null;
+        dailyLimitUsd: number | null;
+        monthlyLimitUsd: number | null;
+        currentSpendUsd: number;
+        periodStart: string;
+        periodEnd: string;
+        softAlertPercent: number;
+        hardStopEnabled: boolean;
+        hardStopTriggered: boolean;
+        alertSent: boolean;
+      } | null;
+      breakdown: {
+        hourly: { spend: number; limit: number | null };
+        daily: { spend: number; limit: number | null };
+        monthly: { spend: number; limit: number | null; periodStart: string | null; periodEnd: string | null };
+        hardStopTriggered: boolean;
+        softAlertPercent: number;
+      };
+    }>('/platform-budget');
+  }
+
+  getPlatformBudgetBreakdown() {
+    return this.fetch<{
+      hourly: { spend: number; limit: number | null };
+      daily: { spend: number; limit: number | null };
+      monthly: { spend: number; limit: number | null; periodStart: string | null; periodEnd: string | null };
+      hardStopTriggered: boolean;
+      softAlertPercent: number;
+    }>('/platform-budget/breakdown');
+  }
+
+  upsertPlatformBudget(data: {
+    hourlyLimitUsd?: number | null;
+    dailyLimitUsd?: number | null;
+    monthlyLimitUsd?: number | null;
+    softAlertPercent?: number;
+    hardStopEnabled?: boolean;
+    periodStart?: string;
+    periodEnd?: string;
+  }) {
+    return this.fetch('/platform-budget', { method: 'PUT', body: JSON.stringify(data) });
+  }
+
+  resetPlatformBudget(body?: { periodStart?: string; periodEnd?: string }) {
+    return this.fetch('/platform-budget/reset', { method: 'POST', body: JSON.stringify(body || {}) });
+  }
+
+  getPlatformBudgetIncidents(params?: { page?: string; pageSize?: string }) {
+    const query = params ? '?' + new URLSearchParams(params as Record<string, string>).toString() : '';
+    return this.fetch<any>(`/platform-budget/incidents${query}`);
+  }
+
   // Approvals
   getApprovals(params?: Record<string, string>) {
     const query = params ? '?' + new URLSearchParams(params).toString() : '';

--- a/packages/db/prisma/migrations/20260513200000_platform_budgets/migration.sql
+++ b/packages/db/prisma/migrations/20260513200000_platform_budgets/migration.sql
@@ -1,0 +1,71 @@
+-- Platform Budgets: org-wide limits (hourly/daily/monthly) that override per-agent limits.
+-- Also extends agent_budgets with nullable daily/hourly limit columns.
+
+-- Budget scope enum for incidents
+CREATE TYPE "BudgetScope" AS ENUM ('HOURLY', 'DAILY', 'MONTHLY');
+
+-- Extend agent_budgets: add nullable daily/hourly limits
+-- (monthly already exists; now three windows live in one table)
+ALTER TABLE "agent_budgets"
+  ADD COLUMN "daily_limit_usd"  DOUBLE PRECISION,
+  ADD COLUMN "hourly_limit_usd" DOUBLE PRECISION;
+
+-- Migrate any existing per-agent daily/hourly limits from agents.llm_config JSON
+-- into the new agent_budgets columns (only for agents that already have a budget row).
+UPDATE "agent_budgets" ab
+SET
+  "daily_limit_usd"  = COALESCE(ab."daily_limit_usd",
+    NULLIF((a."llm_config"->>'dailyBudgetUsd')::text, '')::double precision),
+  "hourly_limit_usd" = COALESCE(ab."hourly_limit_usd",
+    NULLIF((a."llm_config"->>'hourlyBudgetUsd')::text, '')::double precision)
+FROM "agents" a
+WHERE ab."agent_id" = a."id";
+
+-- Platform budgets: one row per org, hourly/daily/monthly all nullable
+CREATE TABLE "platform_budgets" (
+    "id"                   TEXT             NOT NULL,
+    "org_id"               TEXT             NOT NULL,
+    "hourly_limit_usd"     DOUBLE PRECISION,
+    "daily_limit_usd"      DOUBLE PRECISION,
+    "monthly_limit_usd"    DOUBLE PRECISION,
+    "current_spend_usd"    DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "period_start"         TIMESTAMP(3)     NOT NULL,
+    "period_end"           TIMESTAMP(3)     NOT NULL,
+    "soft_alert_percent"   INTEGER          NOT NULL DEFAULT 80,
+    "hard_stop_enabled"    BOOLEAN          NOT NULL DEFAULT true,
+    "alert_sent"           BOOLEAN          NOT NULL DEFAULT false,
+    "hard_stop_triggered"  BOOLEAN          NOT NULL DEFAULT false,
+    "metadata"             JSONB,
+    "created_at"           TIMESTAMP(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"           TIMESTAMP(3)     NOT NULL,
+
+    CONSTRAINT "platform_budgets_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "platform_budgets_org_id_key"  ON "platform_budgets"("org_id");
+CREATE INDEX        "platform_budgets_org_id_idx"  ON "platform_budgets"("org_id");
+
+ALTER TABLE "platform_budgets"
+  ADD CONSTRAINT "platform_budgets_org_id_fkey"
+  FOREIGN KEY ("org_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Platform budget incidents (hourly/daily/monthly scope)
+CREATE TABLE "platform_budget_incidents" (
+    "id"                  TEXT                 NOT NULL,
+    "platform_budget_id"  TEXT                 NOT NULL,
+    "type"                "BudgetIncidentType" NOT NULL,
+    "scope"               "BudgetScope"        NOT NULL,
+    "message"             TEXT                 NOT NULL,
+    "spend_usd"           DOUBLE PRECISION     NOT NULL,
+    "limit_usd"           DOUBLE PRECISION     NOT NULL,
+    "created_at"          TIMESTAMP(3)         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "platform_budget_incidents_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "platform_budget_incidents_platform_budget_id_idx"
+  ON "platform_budget_incidents"("platform_budget_id");
+
+ALTER TABLE "platform_budget_incidents"
+  ADD CONSTRAINT "platform_budget_incidents_platform_budget_id_fkey"
+  FOREIGN KEY ("platform_budget_id") REFERENCES "platform_budgets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Organization {
   plugins      Plugin[]
   repositories Repository[]
   taskTriggers TaskTrigger[]
+  platformBudget PlatformBudget?
 
   @@map("organizations")
 }
@@ -1268,8 +1269,12 @@ model AgentBudget {
   agentId String @map("agent_id")
   agent   Agent  @relation(fields: [agentId], references: [id], onDelete: Cascade)
 
-  // Monthly budget (USD)
+  // Limits (USD). All nullable — NULL means "no limit at this window".
   monthlyLimitUsd Float  @map("monthly_limit_usd")
+  dailyLimitUsd   Float? @map("daily_limit_usd")
+  hourlyLimitUsd  Float? @map("hourly_limit_usd")
+
+  // Monthly counter (daily/hourly are derived from agent_executions on-the-fly)
   currentSpendUsd Float  @default(0) @map("current_spend_usd")
   periodStart     DateTime @map("period_start")
   periodEnd       DateTime @map("period_end")
@@ -1310,6 +1315,62 @@ enum BudgetIncidentType {
   HARD_STOP
   BUDGET_RESET
   MANUAL_OVERRIDE
+}
+
+// ═══════════════════════════════════════════════════
+// PLATFORM BUDGET — org-wide cap, takes priority over per-agent limits
+// ═══════════════════════════════════════════════════
+
+model PlatformBudget {
+  id    String       @id @default(uuid())
+  orgId String       @unique @map("org_id")
+  org   Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  // Limits (USD). All nullable — NULL means "no platform-wide limit at this window".
+  hourlyLimitUsd  Float? @map("hourly_limit_usd")
+  dailyLimitUsd   Float? @map("daily_limit_usd")
+  monthlyLimitUsd Float? @map("monthly_limit_usd")
+
+  // Monthly counter (daily/hourly derived on-the-fly from agent_executions)
+  currentSpendUsd Float    @default(0) @map("current_spend_usd")
+  periodStart     DateTime @map("period_start")
+  periodEnd       DateTime @map("period_end")
+
+  // Alerts & hard stop
+  softAlertPercent  Int     @default(80) @map("soft_alert_percent")
+  hardStopEnabled   Boolean @default(true) @map("hard_stop_enabled")
+  alertSent         Boolean @default(false) @map("alert_sent")
+  hardStopTriggered Boolean @default(false) @map("hard_stop_triggered")
+
+  incidents PlatformBudgetIncident[]
+  metadata  Json?
+  createdAt DateTime                 @default(now()) @map("created_at")
+  updatedAt DateTime                 @updatedAt @map("updated_at")
+
+  @@index([orgId])
+  @@map("platform_budgets")
+}
+
+model PlatformBudgetIncident {
+  id               String         @id @default(uuid())
+  platformBudgetId String         @map("platform_budget_id")
+  platformBudget   PlatformBudget @relation(fields: [platformBudgetId], references: [id], onDelete: Cascade)
+
+  type      BudgetIncidentType
+  scope     BudgetScope // HOURLY | DAILY | MONTHLY
+  message   String             @db.Text
+  spendUsd  Float              @map("spend_usd")
+  limitUsd  Float              @map("limit_usd")
+  createdAt DateTime           @default(now()) @map("created_at")
+
+  @@index([platformBudgetId])
+  @@map("platform_budget_incidents")
+}
+
+enum BudgetScope {
+  HOURLY
+  DAILY
+  MONTHLY
 }
 
 // ═══════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Adds an org-wide **PlatformBudget** that takes priority over per-agent limits, fixing the case where the dashboard's HR/DAY/MO chips show a limit being hit (e.g. DAY $6.10/$6 = 102%) while agents keep running because the runtime only consults per-agent budgets.

## Backend

- `PlatformBudgetsService.checkLimit(orgId)` is now called **before** the per-agent gate in `runtime.service.ts`. If any window's spend ≥ its limit, the execution short-circuits as COMPLETED with the reason in the output.
- `recordSpend()` is **atomic** — `UPDATE col = col + $n` so concurrent executions cannot lose increments. It also re-evaluates fresh hourly/daily spend after the increment and trips `hard_stop_triggered` on whichever window overshoots, closing the race where N parallel runs all pass the gate at 99.9%.
- New `BudgetResetScheduler` (60s tick) auto-clears `hard_stop_triggered` when the tripping window has rolled over (new hour/day/month → spend back under limit). Records `MANUAL_OVERRIDE` incident for audit.

## Schema

- `platform_budgets` and `platform_budget_incidents` tables (1 row per org, three nullable limit columns).
- `BudgetScope` enum (HOURLY | DAILY | MONTHLY).
- `agent_budgets` gains nullable `daily_limit_usd` / `hourly_limit_usd`.

## UI

- New endpoints in `apps/web/src/lib/api.ts` (getPlatformBudget, breakdown, upsert, reset, incidents).
- `/budgets` page gains a Platform Budget Card so admins set org-wide caps without SQL.

## Test plan

- [x] Survival prod was patched in-tree (manual port from `arm`) on 2026-05-13 and is healthy after rebuild.
- [ ] Migration runs cleanly on a copy of production DB (`prisma migrate deploy`).
- [ ] Backend unit test: set HOURLY limit, push spend over via `recordSpend()` × N — verify next `checkLimit()` returns `blocked: true`.
- [ ] Race test: 5 concurrent runs against an org at 99% — verify total spend never exceeds limit by more than 1 execution's worth (atomic increment + post-trip).
- [ ] Scheduler test: trip hourly hard-stop, fast-forward clock to next hour, verify `BudgetResetScheduler` clears flag and writes a MANUAL_OVERRIDE incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)